### PR TITLE
Add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Package to handle D°M'S'' coordinates"
 homepage = "https://github.com/gwbres/dms-coordinates"
 keywords = ["positionning", ]
 categories = ["science",]
+repository = "https://github.com/gwbres/dms-coordinates"
 edition = "2018"
 readme = "README.md"
 


### PR DESCRIPTION
Hi,

Thank you very much for your work on this crate. I noticed that the link to the repository was not in the Cargo.toml. Wasn't sure if it was intentional but decided to send a PR and ask at the same time. It was in the homepage so I was still able to find the repository but took me a bit more effort as it wasn't where I was expecting it to be.