### PR TITLE
Fix cardinal & minites for DMS::from_ddeg_longitude

### DIFF
--- a/src/dms.rs
+++ b/src/dms.rs
@@ -364,7 +364,7 @@ impl DMS {
     /// from given angle expressed in decimal degrees
     pub fn from_ddeg_longitude(angle: f64) -> Self {
         let degrees = angle.abs().floor();
-        let minutes = (angle.abs() - degrees) * 60.0;
+        let minutes = ((angle.abs() - degrees) * 60.0).floor();
         let seconds = (angle.abs() - degrees - minutes / 60.0_f64) * 3600.0_f64;
         let cardinal = if angle < 0.0 {
             Cardinal::West

--- a/src/dms.rs
+++ b/src/dms.rs
@@ -367,9 +367,9 @@ impl DMS {
         let minutes = (angle.abs() - degrees) * 60.0;
         let seconds = (angle.abs() - degrees - minutes / 60.0_f64) * 3600.0_f64;
         let cardinal = if angle < 0.0 {
-            Cardinal::South
+            Cardinal::West
         } else {
-            Cardinal::North
+            Cardinal::East
         };
         Self {
             degrees: (degrees as u16) % 180,


### PR DESCRIPTION
It seems the DMS::from_ddeg_longitude function set the cardinal to South/North which should be West/East for longtitude.

or I have to use with_cardinal and from_ddeg_angle.
```rust
let longitude = DMS::from_ddeg_angle(longitude_angle).with_cardinal(if longitude_angle < 0.0 {
        dms_coordinates::Cardinal::West
    } else {
        dms_coordinates::Cardinal::East
    });
```